### PR TITLE
Add 1.8.x series

### DIFF
--- a/recipe/LICENSE
+++ b/recipe/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2007-2016 Tim Pease
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ about:
   home: https://rubygems.org/gems/{{ name }}
   license: MIT
   license_family: MIT
-  license_file: {{ name }}-{{ version }}/LICENSE
+  license_file: LICENSE
   summary: |
     A a flexible logging library for use in Ruby programs based on the design of
     Java's log4j library. It features a hierarchical logging system, custom level

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "logging" %}
-{% set version = "2.2.2" %}
+{% set version = "1.8.2" %}
 
 package:
   name: rb-{{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://rubygems.org/downloads/{{ name }}-{{ version }}.gem
-  sha256: 963359dbdab725a3320eab179017d20d5b9731d7148e1efa8432c184a48a461a
+  sha256: d7204b5ebacdf44756c1358b24ac78da39f63f5e6bfe0b6ffad0393de69d8c6d
 
 build:
   noarch: generic


### PR DESCRIPTION
Please add the 1.8.x series of rb-logging. It is needed for aws-codedeploy-agent